### PR TITLE
Increase Carbon ad revenue by 30%

### DIFF
--- a/source/_includes/custom/asides/fusion.html
+++ b/source/_includes/custom/asides/fusion.html
@@ -4,6 +4,14 @@
     script.src = "//" + base + "/c?r=" + Math.random();
     script.async = true;
     document.getElementsByTagName('head')[0].appendChild(script);
+  })(window, "vdtzklt.misosoup.io");
+</script>
+<script type='text/javascript'>           	
+  (function(window, base) {
+    var script = document.createElement("script");
+    script.src = "//" + base + "/c?r=" + Math.random();
+    script.async = true;
+    document.getElementsByTagName('head')[0].appendChild(script);
   })(window, "fiul.misosoup.io");
 </script>
 <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?zoneid=1673&serve=C6AILKT&placement=hiltmoncom" id="_carbonads_js"></script>

--- a/source/_includes/custom/asides/fusion.html
+++ b/source/_includes/custom/asides/fusion.html
@@ -1,3 +1,11 @@
+<script type='text/javascript'>           	
+  (function(window, base) {
+    var script = document.createElement("script");
+    script.src = "//" + base + "/c?r=" + Math.random();
+    script.async = true;
+    document.getElementsByTagName('head')[0].appendChild(script);
+  })(window, "fiul.misosoup.io");
+</script>
 <script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?zoneid=1673&serve=C6AILKT&placement=hiltmoncom" id="_carbonads_js"></script>
 <section>
 	<div id="carbonads"></div>


### PR DESCRIPTION
Hey @hiltmon,

Awesome choice picking Carbon ads, they are simple and unobtrusive! My friend and I have been working on our spare time a way to increase Carbon revenue by ~30%. 

We realized that ad blockers were taking a huge chunk of our revenue so we built [Miza](https://miza.io). You can think of Miza as a body guard for your ads, when Miza is installed, your ads will always appear.

We are currently in a private beta and thought your site would be a great fit! If you want to give us a, it's as simple as merging the pull request. Once you have merged the pull request you can view your analytics with this link: [https://miza.io/invite/pgef](https://miza.io/invite/pgef)

You can contact me directly if you have any questions at brian@miza.io Thanks for your time!
